### PR TITLE
Updated readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Depending on which platform you want to use, EITHER follow the "GoG / Steam" OR 
 
 ##### GoG / Steam
 ```diff
-! GOG Galaxy does not work over Windows Remote Desktop. You can use tools like VNC or Chrome Remote Desktop instead.
+! Neither the GOG communications server nor GOG Galaxy works over Windows Remote Desktop. You can use tools like VNC or Chrome Remote Desktop instead. Launching any part of the server over Windows Remote Desktop causes it to not show up in the server listing.
 ```
 1) Install GOG Galaxy (<https://www.gog.com/galaxy>)
 2) Using GOG Galaxy, download Star Wars Battlefront II

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,9 @@ Depending on which platform you want to use, EITHER follow the "GoG / Steam" OR 
 
 ##### GoG / Steam
 ```diff
-! Neither the GOG communications server nor GOG Galaxy works over Windows Remote Desktop. You can use tools like VNC or Chrome Remote Desktop instead. Launching any part of the server over Windows Remote Desktop causes it to not show up in the server listing.
+! Neither the GOG communications server nor GOG Galaxy works over Windows Remote Desktop. 
+You can use tools like VNC or Chrome Remote Desktop instead. 
+Launching any part of the server over Windows Remote Desktop causes it to not show up in the server listing.
 ```
 1) Install GOG Galaxy (<https://www.gog.com/galaxy>)
 2) Using GOG Galaxy, download Star Wars Battlefront II

--- a/readme.md
+++ b/readme.md
@@ -61,8 +61,8 @@ Depending on which platform you want to use, EITHER follow the "GoG / Steam" OR 
 ##### GoG / Steam
 ```diff
 ! Neither the GOG communications server nor GOG Galaxy works over Windows Remote Desktop. 
-You can use tools like VNC or Chrome Remote Desktop instead. 
-Launching any part of the server over Windows Remote Desktop causes it to not show up in the server listing.
+! You can use tools like VNC or Chrome Remote Desktop instead. 
+! Launching any part of the server over Windows Remote Desktop causes it to not show up in the server listing.
 ```
 1) Install GOG Galaxy (<https://www.gog.com/galaxy>)
 2) Using GOG Galaxy, download Star Wars Battlefront II


### PR DESCRIPTION
Clarified some of the problems with Windows Remote Desktop. It's not just GOG that doesn't work, the communications does not either. Having GOG open physically then RDPing in and launching the server after that doesn't work as it won't be found in the masterserver list.

The only way is to do it physically or through another client.